### PR TITLE
Chapter4 test fix

### DIFF
--- a/src/test/java/examples/Chapter4Test.java
+++ b/src/test/java/examples/Chapter4Test.java
@@ -1,8 +1,5 @@
 package examples;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.builder.ResponseSpecBuilder;
 import io.restassured.http.ContentType;
@@ -11,10 +8,6 @@ import io.restassured.specification.ResponseSpecification;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.Request;
-import org.junit.runner.RunWith;
-
-import javax.xml.ws.Response;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
@@ -79,8 +72,8 @@ public class Chapter4Test {
             get("http://zippopotam.us/us/90210").
         then().
             extract().
-            path("places[0].'Beverly Hills'");
+            path("places[0].'place name'");
 
-        Assert.assertEquals(placeName, "Beverly Hills");
+        Assert.assertEquals("Beverly Hills", placeName);
     }
 }


### PR DESCRIPTION
Hey Bas,

first of all thank you for all you effort you put in this educational project. Great job!

When I run the _Chapter4Test_ class one of the test fails:

```java.lang.AssertionError: 
Expected :null
Actual   :Beverly Hills
 <Click to see difference>


	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:118)
	at org.junit.Assert.assertEquals(Assert.java:144)
	at examples.Chapter4Test.requestUsZipCode90210_extractPlaceNameFromResponseBody_assertEqualToBeverlyHills(Chapter4Test.java:84)
```


If it is not intentionally feel free to accept this PR.