### PR TITLE
Start Wiremock programmatically via JUnit Rule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,5 +40,11 @@
             <version>${jackson.databind.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8</artifactId>
+            <version>2.21.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/src/test/java/examples/Chapter5Test.java
+++ b/src/test/java/examples/Chapter5Test.java
@@ -1,11 +1,17 @@
 package examples;
 
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.junit.Rule;
 import org.junit.Test;
 
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
 
 public class Chapter5Test {
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(options().port(9876));
 
     @Test
     public void requestUsZipCode90210_checkPlaceNameInResponseBody_expectBeverlyHills() {

--- a/src/test/java/examples/Chapter6Test.java
+++ b/src/test/java/examples/Chapter6Test.java
@@ -1,14 +1,20 @@
 package examples;
 
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import dataentities.Location;
 import io.restassured.http.ContentType;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
 
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.hasSize;
 
 public class Chapter6Test {
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(options().port(9876));
 
     @Test
     public void requestUsZipCode90210_checkPlaceNameInResponseBody_expectBeverlyHills() {


### PR DESCRIPTION
It is possible to start Wiremock programmatically, no need to start fat .jar manually before running the tests. It defaults to _src/test/resources_ mocks specification files.